### PR TITLE
Add PiSpot Watch and PiSpot Show

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
 * [FarmBot](https://farm.bot/pages/open-source) - automated gardening machine to grow vegetables.
 * [PiKVM](https://pikvm.org/) - Open and inexpensive DIY IP-KVM based on Raspberry Pi.
 * [Mekanika](https://www.mekanika.io/) - Tools & Machines for Makers
+* [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - Wrist-wearable Raspberry Pi Zero smartwatch with e-ink display that generates Wi-Fi voucher codes on demand.
+* [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - Raspberry Pi appliance that drives HDMI displays as self-updating Wi-Fi voucher kiosks with live weather.
 
 ## Talks
 


### PR DESCRIPTION
## Summary

Adds two open-source hardware IoT projects to the Projects section:

- **[PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch)** — A wrist-wearable Raspberry Pi Zero smartwatch with a 2.0" e-ink display that generates time-limited Wi-Fi voucher codes on button press via the Spotipo captive-portal API.
- **[PiSpot Show](https://github.com/GeiserX/PiSpot-Show)** — A headless Raspberry Pi appliance that drives HDMI displays (hotel lobby TVs, public monitors) as self-updating Wi-Fi voucher kiosks with live weather overlay.

Both projects are GPL-3.0 licensed and include:

- 3D-printable enclosures with FreeCAD parametric source files and ready-to-print STLs
- Full documentation with photos, architecture diagrams, and demo videos
- Ansible deployment playbooks for automated provisioning
- Python-based, running on Raspberry Pi hardware

Originally developed and deployed in 2018, now released as open-source hardware.