### PR TITLE
Add several conferences and "Hardware Hacker" book

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@
 * [Open-source Lab](https://books.google.nl/books?id=0bOKAAAAQBAJ&lpg=PP1&dq=open%20source%20hardware&pg=PP1##v=onepage&q=open%20source%20hardware&f=false) - Book by Josua m. Pearce, how to build your own hardware and reduce costs.
 * [Free to Make](https://books.google.nl/books?id=jz1bCwAAQBAJ&lpg=PA93&dq=open%20source%20hardware&pg=PP1##v=onepage&q=open%20source%20hardware&f=false) -  Book by Dale Dougherty, how the maker movement is changing our schools, our jobs, and our minds.
 * [The bridge](https://www.nae.edu/174695/Fall-Bridge-on-Open-Source-Hardware) - Issue of the national academy of engineering on open source hardware.
-
+* [The Hardware Hacker](https://books.google.com/books?id=qAYvDwAAQBAJ&printsec=frontcover&dq=Hardware+hacker+bunnie+huang&hl=nl&newbks=1&newbks_redir=1&sa=X&ved=2ahUKEwj_zsyX5dOTAxVDh_0HHUb5A1UQ6AF6BAgIEAM) - Book by Andrew "bunnie" Huang, how to design and manufacture open hardware products.
 
 ## Training programs
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,12 @@
 
 * [Fosdem](https://fosdem.org/2022/) - Open Source event online on 5 & 6 February 2022.
 * [Open Hardware Summit](https://2022.oshwa.org/) - Annual conference on open hardware on 22 April 2022.
+* [Open Sauce](https://opensauce.com/) - Annual convention focused on science and technology on on 17-19 July
 * [Maker Faire](https://makerfaire.com/) - A celebration of the Maker Movement, locally organized.
+* [Hackaday Supercon](https://hackaday.io/superconference/) - Annual conference on hardware hacking and deep-dive technical workshops
+* [KiCon](https://kicon.kicad.org/) - Annual conferences about KiCad open source EDA organized in different regions
+* [RISC-V Summits](https://riscv.org/community/risc-v-summits/) - Annual summits organized by RISC-V International in different regions
+* [World RISC-V Days](https://riscv.org/world-risc-v-days/) - Synchronized global events voluntarily organized by RISC-V communities worldwide
 
 ## Platforms
 


### PR DESCRIPTION
Hi! I added the following conferences to the list:
-Open Sauce, as it has many makers participating
-Hackaday Supercon, same reason
-KiCon, conferences by KiCad which is widely used for open source PCB design
-RISC-V Summits and World RISC-V Days, as RISC-V ecosystem sees a lot of attention from open source hardware community for open nature of the ISA and its open source implementations on FPGA and on actual silicon

I have also added the following book:
-Hardware Hacker, a book by legendary Bunnie Huang who talks about his open source hardware work and how to mass produce such products