### PR TITLE
Add Latch-Up, ORConf, Supercon; modify FOSDEM, Open Hardware Summit

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@
 
 ## Conferences
 
-* [Fosdem](https://fosdem.org/2022/) - Open Source event online on 5 & 6 February 2022.
-* [Open Hardware Summit](https://2022.oshwa.org/) - Annual conference on open hardware on 22 April 2022.
+* [FOSDEM](https://fosdem.org) - Annual open source event in Brussels.
+* [Open Hardware Summit](https://oshwa.org/events/) - Annual conference on open hardware.
 * [Maker Faire](https://makerfaire.com/) - A celebration of the Maker Movement, locally organized.
+* [Latch-Up](https://fossi-foundation.org/latch-up) - A three-day conference dedicated to free and open source silicon. Hosted in North America every spring.
+* [ORConf](https://fossi-foundation.org/orconf) - Another three-day conference dedicated to free and open source silicon. Hosted in Europe every autumn.
 
 ## Platforms
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@
 * [Maker Faire](https://makerfaire.com/) - A celebration of the Maker Movement, locally organized.
 * [Latch-Up](https://fossi-foundation.org/latch-up) - A three-day conference dedicated to free and open source silicon. Hosted in North America every spring.
 * [ORConf](https://fossi-foundation.org/orconf) - Another three-day conference dedicated to free and open source silicon. Hosted in Europe every autumn.
+* [Hackaday Supercon](https://hackaday.io/superconference/) - A hardware hacking conference hosted by Hackaday.
 
 ## Platforms
 


### PR DESCRIPTION
Added two open source silicon conferences. Also modified FOSDEM and Open Hardware Summit to not specify the year.

Feel free to change the wording if you'd like. :)