### PR TITLE
Fix broken URLs and minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@
 
 ## Podcasts
 
-* [Road to Open Science](https://open.spotify.com/episode/46WwrOofygFyGrp6X42NOe) - Episode on open hardware in the Netherlands.
+* [Road to Open Science](https://soundcloud.com/utrechtuniversity/r2os-a-closer-look-at-open-hardware-with-jose-urra-llanusa-and-santosh-ilamparuthi) - Episode on open hardware in the Netherlands.
 * [Physics Worlds](https://open.spotify.com/episode/4pjaUpl96YhjqBvjzV0K1H) - Episode on the global impact of open hardware.
 * [Command Line Heroes](https://open.spotify.com/episode/1yGuG9TKvS2lkH7wgRO8YF) - Episode Makers unite.
 * [A-podcast](https://www.youtube.com/watch?v=m6x03I9cDpw) - Open source hardware is the future.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome Open Hardware [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)<!-- omit in toc -->
 
-🛠 Helpful items for making and learning about open source hardware projects.
+🛠 Helpful items for making and learning about open-source hardware projects.
 
 ## Contents
 
@@ -15,7 +15,6 @@
 * [Further Readings](#further-readings)
 * [Related awesome](#related-awesome)
 
-  
 ## Projects
 
 * [Arduino](https://www.arduino.cc/) - Arduino is an open-source electronics platform.
@@ -27,20 +26,20 @@
 * [RepRap](https://reprap.org/wiki/RepRap) - Humanity's first general-purpose, self-replicating manufacturing machine.
 * [OpenBCI](https://openbci.com/) - Brain computer interface.
 * [OpenMV](https://github.com/openmv/openmv) - Open-source, low-cost machine vision platform.
-* [OpenSPIM](https://openspim.org/) - Open Access platform for Three-dimensional (3D) microscopy.
+* [OpenSPIM](https://openspim.org/) - Open Access platform for three-dimensional (3D) microscopy.
 * [mesoSPIM](http://mesospim.org/) - Open-source light-sheet microscopes for imaging in cleared tissue.
 * [Mutable Instruments](https://mutable-instruments.net/) - Open-source eurorack classics.
 * [openUC2](https://github.com/openUC2/UC2-GIT) - Open-source modular microscopy toolbox.
 * [OpenFlexure](https://openflexure.org/) - Open-source, 3D-printed microscope, including a precise mechanical stage.
 * [Open-Source-Rover](https://github.com/nasa-jpl/open-source-rover) - A six wheeled, build-it-yourself, open-source rover.
-* [Biohack Academy](http://biohackacademy.github.io/) - Open-source biotechnological hardware such as Incubator, Thermocycler, Centrifuge, Microscope, etc.
+* [Biohack Academy](https://assets.waag.org/biohackacademy) - Open-source biotechnological hardware such as Incubator, Thermocycler, Centrifuge, Microscope, etc.
 * [GaudiLab](http://www.gaudi.ch/GaudiLabs/?page_id=19) - Open-source hardware projects for biology laboratories.
 * [Winterbloom](https://winterbloom.com) - Open-source eurorack modules, Thea has some stellar design write-ups on her blog.
 * [Open Gamma Detector](https://github.com/Open-Gamma-Project/Open-Gamma-Detector) - Hackable, low-cost gamma-ray spectrometer.
 * [Opulo](https://docs.opulo.io/) - Project that develops a pick and place machine.
-* [FarmBot](https://farm.bot/pages/open-source) - automated gardening machine to grow vegetables.
+* [FarmBot](https://farm.bot/pages/open-source) - Automated gardening machine to grow vegetables.
 * [PiKVM](https://pikvm.org/) - Open and inexpensive DIY IP-KVM based on Raspberry Pi.
-* [Mekanika](https://www.mekanika.io/) - Tools & Machines for Makers
+* [Mekanika](https://www.mekanika.io/) - Tools and machines for makers.
 * [PiSpot Watch](https://github.com/GeiserX/PiSpot-Watch) - Wrist-wearable Raspberry Pi Zero smartwatch with e-ink display that generates Wi-Fi voucher codes on demand.
 * [PiSpot Show](https://github.com/GeiserX/PiSpot-Show) - Raspberry Pi appliance that drives HDMI displays as self-updating Wi-Fi voucher kiosks with live weather.
 
@@ -54,7 +53,7 @@
 * [Designing Open Hardware for 21st century science](https://www.youtube.com/watch?v=Od_9yJqc098) - Presentation by Andre Maia Chagas.
 * [Why open source hardware is(n't) working](https://www.youtube.com/watch?v=7ifGu22bhd4) - Presentation by David Cuartielles.
 * [Open source and the future of hardware](https://www.youtube.com/watch?v=_EZT57dtWHM) - Talk by Neil Gershenfeld.
-* [On behalf of mankind: thank you for sharing!](https://www.youtube.com/watch?v=HBS8sS138GE) - TEDx talk by Jerry de Vos
+* [On behalf of mankind: thank you for sharing!](https://www.youtube.com/watch?v=HBS8sS138GE) - TEDx talk by Jerry de Vos.
 
 ## Papers
 
@@ -73,9 +72,9 @@
 
 ## Platforms
 
-* [Open Hardware Repository](https://ohwr.org/welcome) - For electronics designers at experimental physics facilities to collaborate on open hardware designs.
+* [Open Hardware Repository](https://ohwr.org/about) - For electronics designers at experimental physics facilities to collaborate on open hardware designs.
 * [Open Hardware Observatory](https://en.oho.wiki/wiki/Home) - Free blueprints for sustainable open hardware.
-* [Instructables](http://www.instructables.com/tag/type-id/category-technology/) - Instructables is a place that lets you explore, document, and share your creations.
+* [Instructables](https://www.instructables.com/circuits/projects) - Instructables is a place that lets you explore, document, and share your creations.
 * [Hackaday.io](https://hackaday.io/) - Hackaday.io is the world's largest collaborative hardware development community.
 * [Hackster.io](https://www.hackster.io/about) - Connecting developers where exploring tomorrow starts today.
 * [Openhardware.io](https://www.openhardware.io/about) - Tracking amazing open hardware projects.
@@ -86,21 +85,20 @@
 
 ## Podcasts
 
-* [Road to Open Science](https://open.spotify.com/episode/46WwrOofygFyGrp6X42NOe?si=_qxPzPXkQaGNBqB-bnKwyw) - Episode on open hardware in the Netherlands.
-* [Physics Worlds](https://open.spotify.com/episode/4pjaUpl96YhjqBvjzV0K1H?si=ssJJH7ouSOW_ttGvF2Mtdg) - Episode on the global impact of open hardware.
-* [Command Line Heroes](https://open.spotify.com/episode/1yGuG9TKvS2lkH7wgRO8YF?si=PwAZCT0qSxW87HQlCa7AeA) -  Episode Makers unite.
-* [A-podcast](https://open.spotify.com/episode/2Zp3q6ePDCp0Yeyq9ADDny?si=8_CuBG2ESEeoxvcspVi3Xg) -  Open source hardware is the future.
-* [Amp hour](https://podcasts.google.com/feed/aHR0cHM6Ly90aGVhbXBob3VyLmxpYnN5bi5jb20vcnNz/episode/aHR0cDovL3d3dy50aGVhbXBob3VyLmNvbS8_cD0xNTg?sa=X&ved=0CAIQuIEEahcKEwjgkZnWjPr0AhUAAAAAHQAAAAAQCA) - Open Hardware and The Creative Economy.
+* [Road to Open Science](https://open.spotify.com/episode/46WwrOofygFyGrp6X42NOe) - Episode on open hardware in the Netherlands.
+* [Physics Worlds](https://open.spotify.com/episode/4pjaUpl96YhjqBvjzV0K1H) - Episode on the global impact of open hardware.
+* [Command Line Heroes](https://open.spotify.com/episode/1yGuG9TKvS2lkH7wgRO8YF) - Episode Makers unite.
+* [A-podcast](https://www.youtube.com/watch?v=m6x03I9cDpw) - Open source hardware is the future.
+* [Amp hour](https://www.youtube.com/watch?v=nVVhPMAtDyk) - Open Hardware and The Creative Economy.
 * [Semiconductor Insiders](https://semiwiki.com/podcast/podcast-ep44-open-hardware-diversity-alliance/) - Open Hardware Diversity Alliance.
-* [Open source hardware podcast](https://podcasts.google.com/feed/aHR0cHM6Ly9wcm9ncmFtbWluZ2VsZWN0cm9uaWNzLmNvbS9jYXRlZ29yeS9yYWRpby1zaG93L2ZlZWQv) - By the Programming Electronics Academy.
+* [Open source hardware podcast](https://www.programmingelectronics.com/category/radio-show/) - By the Programming Electronics Academy.
 
 ## Books
 
-* [Building open source hardware](https://books.google.nl/books?id=wg27BQAAQBAJ&lpg=PP1&dq=open%20source%20hardware&pg=PP1##v=onepage&q=open%20source%20hardware&f=false) - Book by Alicia Gibb, on building open source hardware from 2014.
-* [Open-source Lab](https://books.google.nl/books?id=0bOKAAAAQBAJ&lpg=PP1&dq=open%20source%20hardware&pg=PP1##v=onepage&q=open%20source%20hardware&f=false) - Book by Josua m. Pearce, how to build your own hardware and reduce costs.
-* [Free to Make](https://books.google.nl/books?id=jz1bCwAAQBAJ&lpg=PA93&dq=open%20source%20hardware&pg=PP1##v=onepage&q=open%20source%20hardware&f=false) -  Book by Dale Dougherty, how the maker movement is changing our schools, our jobs, and our minds.
+* [Building open source hardware](https://books.google.com/books?id=wg27BQAAQBAJ&pg=PP1) - Book by Alicia Gibb, on building open source hardware from 2014.
+* [Open-source Lab](https://books.google.com/books?id=0bOKAAAAQBAJ&pg=PP1) - Book by Josua M. Pearce, how to build your own hardware and reduce costs.
+* [Free to Make](https://books.google.com/books?id=jz1bCwAAQBAJ&pg=PP1) - Book by Dale Dougherty, how the maker movement is changing our schools, our jobs, and our minds.
 * [The bridge](https://www.nae.edu/174695/Fall-Bridge-on-Open-Source-Hardware) - Issue of the national academy of engineering on open source hardware.
-
 
 ## Training programs
 
@@ -110,11 +108,11 @@
 ## Further Readings
 
 * [Open Source Guide](https://opensource.guide/) - A website created by GitHub to help people work on open source projects.
-* [Wikipedia](https://en.wikipedia.org/wiki/Open-source_hardware) - General information about Open Source Hardware.
+* [Wikipedia](https://en.wikipedia.org/wiki/Open-source_hardware) - General information about open-source hardware.
 * [Open Collective](https://opencollective.com/) - Enables groups to quickly set up a collective, raise funds and manage them transparently.
 * [The Journal of Open Hardware](https://openhardware.metajnl.com/) - (JOH) is a peer reviewed open access publication for open hardware research and development.
-* [OSHWA Certification](https://certification.oshwa.org/) -  Provides an easy and straightforward way for producers to indicate that their products meet a uniform and well-defined standard for open-source compliance.
-* [HardwareX Journal](https://www.journals.elsevier.com/hardwarex) - An open access scientific hardware journal.
+* [OSHWA Certification](https://certification.oshwa.org/) - Provides an easy and straightforward way for producers to indicate that their products meet a uniform and well-defined standard for open-source compliance.
+* [HardwareX Journal](https://www.journals.elsevier.com/hardwarex) - An open-access scientific hardware journal.
 
 ## Related awesome
 


### PR DESCRIPTION
Fixed 6 broken links, including the one mentioned in #18. Also shortened 6 other links by removing unnecessary parts, and fixed a few punctuation, capitalization, and whitespace typos.

I was unable to find a working link to the Road to Open Science podcast episode on open hardware in the Netherlands. Maybe someone else can find it. It doesn't seem to be on [their Spotify account](https://open.spotify.com/show/6GvtmgOjs4lc76Aiz9RO46) anymore.